### PR TITLE
Turn Prettier errors to warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = {
   plugins: ['@typescript-eslint', 'prettier'],
   rules: {
     'prettier/prettier': [
-      'error',
+      'warn',
       {
         singleQuote: true,
         semi: false,


### PR DESCRIPTION
This has bugged me since the beginning of time; when writing code you can't immediately tell if your code is broken, or just waiting to be formatted by a subsequent `Cmd/Ctrl + S`.

Now formatting errors are yellow, and compile errors red.

feelsgoodman.jpg