### PR TITLE
Add use-consistent-spelling rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Finally, you'll need to make sure the `eslint` working copy has all its dependen
 
 You can now successfully `npm run lint` in the `frontend` repo, while making changes here.
 
+## Developing custom rules
+
+To see how the AST you're matching against looks like, paste your code sample to https://astexplorer.net/ and select either `@babel/parser` or `@typescript-eslint/parser`.
+
 ## Releasing changes
 
 ```

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = {
    */
   rules: {
     "no-relative-imports": require("./rules/no-relative-imports"),
+    "use-consistent-spelling": require("./rules/use-consistent-spelling"),
   },
   configs: {
     /**
@@ -41,6 +42,7 @@ module.exports = {
           },
         ],
         "swarmia-dev/no-relative-imports": "error",
+        "swarmia-dev/use-consistent-spelling": "warn",
         "@typescript-eslint/no-shadow": "warn",
         "@typescript-eslint/no-floating-promises": "error",
         "@typescript-eslint/no-submodule-imports": 0,

--- a/rules/use-consistent-spelling.js
+++ b/rules/use-consistent-spelling.js
@@ -1,14 +1,13 @@
 const corrections = [
   // Simple search & replace:
   ["PR's", "PRs"],
-  [/git hub/i, "GitHub"],
   // Short strings need to be between word boundaries to limit false positives:
   [/\b[Pp]r\b/, "PR"],
   [/\bslack\b/, "Slack"],
   [/\bjira\b/, "Jira"],
   [/\bgithub\b/, "GitHub"],
-  // Some cases depend on context, e.g. is this the first word(s) of a sentence:
-  ["Pull Request", ["pull request", "Pull request"]],
+  // If there's multiple correct spellings, they can all be listed, for example:
+  // ["Pull Request", ["pull request", "Pull request"]],
 ];
 
 module.exports = {

--- a/rules/use-consistent-spelling.js
+++ b/rules/use-consistent-spelling.js
@@ -1,0 +1,67 @@
+const corrections = [
+  // Simple search & replace:
+  ["PR's", "PRs"],
+  [/git hub/i, "GitHub"],
+  // Short strings need to be between word boundaries to limit false positives:
+  [/\b[Pp]r\b/, "PR"],
+  [/\bslack\b/, "Slack"],
+  [/\bjira\b/, "Jira"],
+  [/\bgithub\b/, "GitHub"],
+  // Some cases depend on context, e.g. is this the first word(s) of a sentence:
+  ["Pull Request", ["pull request", "Pull request"]],
+];
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Looks for common misspellings of common terms, in strings that are potentially user-visible",
+    },
+    fixable: "code",
+    schema: [], // this rule uses no options
+  },
+  create: (context) => ({
+    Literal: matcher(context),
+    JSXText: matcher(context),
+  }),
+};
+
+function matcher(context) {
+  return (node) => {
+    if (
+      typeof node.value !== "string" || // not a string literal -> don't care
+      !node.value.match(/\s/) || // string doesn't include any whitespace -> probably not a user-visible string
+      context.getFilename().match(/\.test\.tsx?$/) || // it's annoying to nag about consistent spelling in test code -> don't
+      node.value.match(/https?:\/\//i) // looks like a URL
+    ) {
+      return; // this looks like a false positive
+    }
+    corrections.forEach(([search, replace]) => {
+      const match = node.value.match(search);
+      if (match) {
+        if (typeof replace === "string") {
+          context.report({
+            node,
+            message: `Replace inconsistent spelling of "${match[0]}" with "${replace}"`,
+            fix: (fixer) => {
+              return fixer.replaceTextRange(
+                [
+                  node.range[0] + match.index + 1,
+                  node.range[0] + match.index + match[0].length + 1,
+                ],
+                replace
+              );
+            },
+          });
+        } else {
+          const options = replace.map((r) => `"${r}"`).join(" or ");
+          context.report({
+            node,
+            message: `Replace inconsistent spelling of "${match[0]}" with ${options}`,
+          });
+        }
+      }
+    });
+  };
+}


### PR DESCRIPTION
Inspired [by noticing how we have inconsistent spelling for "PRs"](https://swarmia.slack.com/archives/CQMQB3R2Q/p1610626609010600) (and lack of proper hobbies 😵), I thought to try and automate checking for them in potentially user-visible strings.

This actually works quite well, and finds a bunch of true positives in both `rapu` and `frontend`.

The only question we'd first need to settle though is [how do we want to capitalize headings](https://swarmia.slack.com/archives/CQMQB3R2Q/p1611493042027400?thread_ts=1610626609.010600&cid=CQMQB3R2Q). Depending on that, the rule about how to spell "pull requests" may or may not end up being useful.