### PR TITLE
Standardize GitHub preposition

### DIFF
--- a/rules/use-consistent-spelling.js
+++ b/rules/use-consistent-spelling.js
@@ -1,6 +1,7 @@
 const corrections = [
   // Simple search & replace:
   ["PR's", "PRs"],
+  [/(on|at) GitHub/, "in GitHub"], // see https://swarmia.slack.com/archives/CQMQB3R2Q/p1613989715007700?thread_ts=1613988804.005600&cid=CQMQB3R2Q
   // Short strings need to be between word boundaries to limit false positives:
   [/\b[Pp]r\b/, "PR"],
   [/\bslack\b/, "Slack"],


### PR DESCRIPTION
```
/Users/jareware/projects/swarmia/frontend/src/Pages/WorkingAgreements/WorkingAgreements/NoDirectPushesToMainBranch/NoDirectPushesToMainBranch.tsx
  20:5  warning  Replace inconsistent spelling of "on GitHub" with "in GitHub"  swarmia-dev/use-consistent-spelling
```