### PR TITLE
Update eslint-prettier-config to 8.1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = {
       extends: [
         "eslint:recommended", // start from the default ESLint config
         "plugin:@typescript-eslint/recommended", // add TypeScript-specific default config
-        "prettier/@typescript-eslint", // disable TypeScript rules that would clash with how Prettier does formatting
+        "prettier", // disable TypeScript rules that would clash with how Prettier does formatting
         "plugin:prettier/recommended", // disable JavaScript rules that would clash with how Prettier does formatting
         "plugin:jest/recommended",
         "plugin:security/recommended",

--- a/package-lock.json
+++ b/package-lock.json
@@ -394,12 +394,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint-config-prettier": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.12.0.tgz",
-      "integrity": "sha512-9jWPlFlgNwRUYVoujvWTQ1aMO8o6648r+K7qU7K5Jmkbyqav1fuEZC0COYpGBxyiAJb65Ra9hrmFx19xRGwXWw==",
-      "requires": {
-        "get-stdin": "^6.0.0"
-      }
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.1.0.tgz",
+      "integrity": "sha512-oKMhGv3ihGbCIimCAjqkdzx2Q+jthoqnXSP+d86M9tptwugycmTFdVR4IpLgq2c4SHifbwO90z2fQ8/Aio73yw=="
     },
     "eslint-config-react": {
       "version": "1.1.7",
@@ -621,11 +618,6 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
       }
-    },
-    "get-stdin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
     },
     "glob-parent": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/eslint-plugin": "4.4.1",
     "@typescript-eslint/parser": "4.4.1",
     "babel-eslint": "10.1.0",
-    "eslint-config-prettier": "6.12.0",
+    "eslint-config-prettier": "8.1.0",
     "eslint-config-react": "1.1.7",
     "eslint-loader": "4.0.2",
     "eslint-plugin-jest": "24.1.3",


### PR DESCRIPTION
`eslint-prettier-config` removed `prettier/@typescript-eslint` from npm repository and consolidated all different configs under `prettier`. To reflect this change, we need to bump eslint-prettier-config to latest version and fix the config.

I tried with `frontend` and `rapu` and both passed with this config.

To make the builds pass, we need to bump `eslint-plugin-swarmia-dev` as well once this is published.