### PR TITLE
Add release script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.history

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.history
+.github
+contrib/
+README.md

--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ To see how the AST you're matching against looks like, paste your code sample to
 
 ## Releasing changes
 
+After a new PR has been merged to `master`:
+
 ```
-git checkout master
-npm version patch # or "minor" or "major"
-git push --tags origin master
-npm publish
+./contrib/create-release patch # or "minor" or "major"
+./contrib/create-bump-pr frontend
+./contrib/create-bump-pr rapu
 ```

--- a/contrib/create-bump-pr
+++ b/contrib/create-bump-pr
@@ -12,6 +12,8 @@ repo="$1"
 dir="$(mktemp -d)"
 branch="bump-eslint-plugin-swarmia-dev"
 
+set -x
+
 git clone --depth=1 "git@github.com:swarmia/$repo.git" "$dir"
 cd "$dir"
 git checkout -b "$branch"
@@ -19,5 +21,5 @@ npm install eslint-plugin-swarmia-dev@latest
 git add package.json package-lock.json
 git commit -m "Bump eslint-plugin-swarmia-dev to latest"
 git push -u origin HEAD --force
-open "https://github.com/swarmia/$repo/compare/$branch?expand=1"
+open "https://github.com/swarmia/$repo/compare/$branch?expand=1&labels=dependencies" # https://docs.github.com/en/github/managing-your-work-on-github/about-automation-for-issues-and-pull-requests-with-query-parameters#supported-query-parameters
 rm -rf "$dir"

--- a/contrib/create-release
+++ b/contrib/create-release
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail # exit on error; treat unset variables as errors; exit on errors in piped commands
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $(basename $0) TYPE"
+  echo 'Where: TYPE is one of "major", "minor" or "patch"'
+  exit 1
+fi
+
+if [ "$(git diff-index HEAD)" != "" ] || [ "$(git ls-files --others --exclude-standard)" != "" ]; then
+  echo -e "Error: Please make releases with a clean working copy, so unwanted changes or untracked files don't accidentally end up on npm"
+  exit 1
+fi
+
+git checkout master
+git pull --rebase
+npm version "$1"
+git push --tags origin master
+npm publish --dry-run
+
+echo "Do the above package contents look correct?"
+echo "They will be made PUBLICLY AVAILABLE on npm!"
+echo "Press Enter to continue, Ctrl+C to abort."
+read
+
+npm publish


### PR DESCRIPTION
It's surprisingly easy to accidentally include unwanted stuff in the package with `npm publish`.

This should help standardize the release process further.