### PR TITLE
Add script for creating bump PR's in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,5 @@ After a new PR has been merged to `master`:
 
 ```
 ./contrib/create-release minor # or "patch" or "major"
-./contrib/create-bump-pr frontend
-./contrib/create-bump-pr rapu
+./contrib/create-bump-prs
 ```

--- a/contrib/create-bump-prs
+++ b/contrib/create-bump-prs
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail # exit on error; treat unset variables as errors; exit on errors in piped commands
+
+./contrib/create-bump-pr rapu &
+./contrib/create-bump-pr frontend &
+
+wait


### PR DESCRIPTION
I've been automating the ESLint-change-related process a tiny bit every time I need to touch this repo, and send PR's to the others.

This time it's adding a script that runs the other script for both repos, and in parallel (it's npm stuff, so it takes a while).