### PR TITLE
Use less greedy regex for new spelling rule

### DIFF
--- a/rules/use-consistent-spelling.js
+++ b/rules/use-consistent-spelling.js
@@ -2,7 +2,7 @@ const corrections = [
   // Simple search & replace:
   ["PR's", "PRs"],
   [/(on|at) GitHub/, "in GitHub"], // see https://swarmia.slack.com/archives/CQMQB3R2Q/p1613989715007700?thread_ts=1613988804.005600&cid=CQMQB3R2Q
-  [/sub.*issue/i, "child issue"],
+  [/sub.?issue/i, "child issue"],
 
   // Short strings need to be between word boundaries to limit false positives:
   [/\b[Pp]r\b/, "PR"],


### PR DESCRIPTION
Should have looked at the results more carefully.

Using `.*` caused e.g. `SubGroupIssue` to match, which is a bit pointless.

Sorry about the churn.