### PR TITLE
Never allow unnecessary curly braces

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,6 +108,10 @@ module.exports = {
         "react/prop-types": 0,
         "react-hooks/rules-of-hooks": "error",
         "react-hooks/exhaustive-deps": "warn",
+        "react/jsx-curly-brace-presence": [
+          "error",
+          { props: "never", children: "never" },
+        ],
         "react/no-unstable-nested-components": [
           "error",
           { allowAsProps: true }, // <SomeComponent footer={() => <div />} /> should still be allowed


### PR DESCRIPTION
`<Component prop={'value'} />` will be autofixed to `<Component prop="value" />`