### PR TITLE
Change @typescript-eslint/return-await to level error with 'always' config

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,10 @@ module.exports = {
         // These could also be promoted to baseline, but we already seem to follow these rules without too much pain for "react" projects:
         "@typescript-eslint/no-explicit-any": 0,
         "@typescript-eslint/ban-types": 0,
+        // Added for node projects, because these settings mostly improve stack traces only in V8,
+        // while possibly adding slight perf overhead in other engines.
+        "no-return-await": "off",
+        "@typescript-eslint/return-await": ["error", "always"],
       },
     },
 


### PR DESCRIPTION
This will be a change that affects the code bases largely, but fortunately it is auto-fixable. This eslint change aims to improve two scenarios:

1. Prevent easy-to-miss bugs with async / await in try-catch blocks. This issue describes the bug best:
    * https://github.com/typescript-eslint/typescript-eslint/issues/994
2. Improve async stack traces. The improvement is only (afaik) applicable to V8 engine, which node uses. More from this below.

The community seems to be divided on the topic. Here's a few opposing opinions about why one should _not_ use `return await` convention: 
* https://github.com/airbnb/javascript/issues/2437


Want to see the stack trace improvements in practice? Just save this `test.js` and run `node test.js` to see the effect.

```js
(function () {
  async function foo() {
    return await bar();
  }

  async function foo2() {
    return bar();
  }

  async function bar() {
    await Promise.resolve();
    throw new Error('BEEP BEEP');
  }

  foo().catch(error => console.log(error.stack));
  foo2().catch(error => console.log(error.stack));
})()
```

The result is that `return await bar()` has a better stack trace:

```
➜  ~ node code/rapu/test.js
Error: BEEP BEEP
    at bar (/Users/kimmo/code/rapu/test.js:14:11)
    at async foo (/Users/kimmo/code/rapu/test.js:4:12)
Error: BEEP BEEP
    at bar (/Users/kimmo/code/rapu/test.js:14:11)
``` 

