### PR TITLE
Disable JSX uses react and JSX in scope rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,6 +120,8 @@ module.exports = {
           "error",
           { allowAsProps: true }, // <SomeComponent footer={() => <div />} /> should still be allowed
         ],
+        "react/jsx-uses-react": "off",
+        "react/react-in-jsx-scope": "off"
       },
       settings: {
         react: {


### PR DESCRIPTION
Disable the rules for requiring `React` to be imported in JSX context.

The new JSX loader supports using JSX without importing React: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

This also started failing with updated VSCode selecting different workspace Typescript version.