### PR TITLE
Disallow comma operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,5 @@ Make sure you've logged-in to NPM (`npm login`) using the `swarmia` user before 
 
 After a new PR has been merged to `master`:
 
-```
-./contrib/create-release minor # or "patch" or "major"
-./contrib/create-bump-prs
-```
+    ./contrib/create-release minor # or "patch" or "major"
+    ./contrib/create-bump-prs

--- a/index.js
+++ b/index.js
@@ -61,6 +61,12 @@ module.exports = {
         ],
         "no-console": "warn",
         "no-debugger": "warn",
+        "no-sequences": [
+          "error",
+          {
+            "allowInParentheses": false
+          }
+        ],
         "jest/no-focused-tests": "warn",
         "security/detect-non-literal-fs-filename": 0, // produces a lot of false positives
         "security/detect-object-injection": 0, // discussed in: https://github.com/swarmia/hook/pull/99#discussion_r553338159


### PR DESCRIPTION
https://eslint.org/docs/latest/rules/no-sequences

Disallow comma operator. It's almost always a bad idea to use it in prod/test code because of the questionable readability, and it is a bit too easy to misuse unnoticed.

Now disallowed e.g. this sneaky thing that would only assign `x` (and not the function) into `logAndReturn` if `x` is in scope; otherwise, "Uncaught ReferenceError: x is not defined." This is because comma operator precedence is lower than the arrow operator: 

```
const logAndReturn = (x: any) => logger.info("some message"), x
```

Disallow even in parentheses:

```
const logAndReturn = (x: any) => (logger.info("some message"), x)
```

Comma operator might be useful for debugging locally (as shown in the second example) but don't let that unintentionally past the linter into prod code.