### PR TITLE
Have return-assingment to always produce an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ module.exports = {
           },
         ],
         "no-console": "warn",
+        "no-return-assign": ["error", "always"],
         "no-debugger": "warn",
         "no-sequences": [
           "error",


### PR DESCRIPTION
Not having this on would allow footguns like `[{ x: 0 }].find(o => (o.x = 1))` to be uncaught.