### PR TITLE
Downgrade eslint-plugin-security to compatible 1.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "eslint-plugin-prettier": "5.1.3",
         "eslint-plugin-react": "7.33.2",
         "eslint-plugin-react-hooks": "4.6.0",
-        "eslint-plugin-security": "2.1.0",
+        "eslint-plugin-security": "1.7.1",
         "eslint-webpack-plugin": "4.0.1",
         "prettier": "3.2.2",
         "typescript": "5.3.3"
@@ -2362,9 +2362,9 @@
       }
     },
     "node_modules/eslint-plugin-security": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-2.1.0.tgz",
-      "integrity": "sha512-ywxclP954bf8d3gr6KOQ/AFc+PRvWuhOxtPOEtiHmVYiZr/mcgQtmSJq6+hTEXC5ylTjHnPPG+PEnzlDiWMXbQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-1.7.1.tgz",
+      "integrity": "sha512-sMStceig8AFglhhT2LqlU5r+/fn9OwsA72O5bBuQVTssPCdQAOQzL+oMn/ZcpeUY6KcNfLJArgcrsSULNjYYdQ==",
       "dependencies": {
         "safe-regex": "^2.1.1"
       }
@@ -7080,9 +7080,9 @@
       "requires": {}
     },
     "eslint-plugin-security": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-2.1.0.tgz",
-      "integrity": "sha512-ywxclP954bf8d3gr6KOQ/AFc+PRvWuhOxtPOEtiHmVYiZr/mcgQtmSJq6+hTEXC5ylTjHnPPG+PEnzlDiWMXbQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-1.7.1.tgz",
+      "integrity": "sha512-sMStceig8AFglhhT2LqlU5r+/fn9OwsA72O5bBuQVTssPCdQAOQzL+oMn/ZcpeUY6KcNfLJArgcrsSULNjYYdQ==",
       "requires": {
         "safe-regex": "^2.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-plugin-prettier": "5.1.3",
     "eslint-plugin-react": "7.33.2",
     "eslint-plugin-react-hooks": "4.6.0",
-    "eslint-plugin-security": "2.1.0",
+    "eslint-plugin-security": "1.7.1",
     "eslint-webpack-plugin": "4.0.1",
     "prettier": "3.2.2",
     "typescript": "5.3.3"


### PR DESCRIPTION
Looks like `eslint-plugin-security` 2.x causes trouble in several dependent projects, possibly related to the way ESLint has been configured. Downgrade to latest 1.x for now.

Sample error we get with 2.x:

```
> tsc --noEmit && eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0


Oops! Something went wrong! :(

ESLint: 8.28.0

TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'Object'
    |     property 'security' -> object with constructor 'Object'
    |     property 'configs' -> object with constructor 'Object'
    |     property 'recommended' -> object with constructor 'Object'
    --- property 'plugins' closes the circle
Referenced from: /home/runner/work/reponame/node_modules/eslint-plugin-swarmia-dev/index.js
    at JSON.stringify (<anonymous>)
    at /home/runner/work/reponame/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:2135:45
    at Array.map (<anonymous>)
    at ConfigValidator.formatErrors (/home/runner/work/reponame/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:2126:23)
    at ConfigValidator.validateConfigSchema (/home/runner/work/reponame/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:2156:84)
    at ConfigArrayFactory._normalizeConfigData (/home/runner/work/reponame/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:2998:19)
    at ConfigArrayFactory._loadExtendedPluginConfig (/home/runner/work/reponame/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:3218:25)
    at ConfigArrayFactory._loadExtends (/home/runner/work/reponame/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:3133:29)
    at ConfigArrayFactory._normalizeObjectConfigDataBody (/home/runner/work/reponame/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:30)
    at _normalizeObjectConfigDataBody.next (<anonymous>)
Error: Process completed with exit code 2.
```